### PR TITLE
Expand shortened link in appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 install:
-  - ps: Start-FileDownload "https://git.io/vq9LX"; . .\install.ps1
+  - ps: Start-FileDownload "https://raw.githubusercontent.com/carllerche/travis-rust-matrix/master/install.ps1"; . .\install.ps1
 
 platform:
   - x86


### PR DESCRIPTION
Short link seems to alter the destination file name. Using the full path
works as expected.
