### PR TITLE
Add CARGOOPTS env var for passing options to cargo

### DIFF
--- a/test
+++ b/test
@@ -105,7 +105,7 @@ reset_manifest() {
 }
 
 # Finally run the tests
-cargo test --target $TARGET_HOST || {
+cargo test $CARGOOPTS --target $TARGET_HOST || {
   reset_manifest
   exit 1
 }


### PR DESCRIPTION
This allows users to specify `--verbose`, for example.
