### PR TITLE
Support crate names with dashes when cross-compiling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 
-name        = "matrix"
+name        = "matrix-test"
 description = "Example rust project configured for a matrix build"
 version     = "0.1.0"
 authors     = ["Carl Lerche <me@carllerche.com>"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 /// Returns a quote from the Matrix movie
 ///
 /// ```
-/// println!("{}", matrix::quote());
+/// println!("{}", matrix_test::quote());
 /// ```
 pub fn quote() -> &'static str {
     "There is no spoon."

--- a/test
+++ b/test
@@ -88,6 +88,9 @@ BCK_FILE="Cargo.toml.cross-compile-bck"
     else
       # First, extract the name of the lib, assume it is the first value
       LIB_NAME=$(cat $BCK_FILE | grep 'name *=' | head -n 1 | awk -F '"' '{print $2}')
+      # Second, normalize the name by converting dashes to underscores.
+      # This is required by the [lib] directive (see issue #4)
+      LIB_NAME="$(echo "$LIB_NAME" | tr - _)"
 
       cp $BCK_FILE Cargo.toml
       echo "[lib]" >> Cargo.toml


### PR DESCRIPTION
- Normalize crate names by converting dashes to underscores when generating the `[lib]` section of `Cargo.toml` for a cross-compile
- Change the name of the test crate from `matrix` to `matrix-test` to test this fix
- Closes #4